### PR TITLE
Update RPC task doc: add GuardCrashAtClient and specify event-exception aggregation

### DIFF
--- a/TODO_RPC_Tasks.md
+++ b/TODO_RPC_Tasks.md
@@ -9,7 +9,7 @@ investigate repro
 
 ## Task 1
 
-Update the current sample `Rpc/Inheritance`, add following events to `IOne` and `ITwo`:
+Update the current sample `Rpc/Inheritance`, add following events to `IOne` and `ITwo`, and add `GuardCrashAtClient` to `IDerived`:
 ```Workflow
 interface IOne
 {
@@ -20,45 +20,67 @@ interface ITwo
 {
   event CrashAtClient();
 }
-```
 
-In `CreateDerived`, the implementation will attach an handler to `CrashAtServer`, raise "CrashedAtServer".
-In `clientMain`, attach an handler to `CrashAtClient`, raise "CrashedAtClient".
-
-Now we have to call them to test the exception. Add these function `GuardCrashAtClient` to `IDerived` and `clientMain` call them this:
-```Workflow
-try { derived.CrashAtServer(); } catch (ex) { $"$(s)[$(ex)]"; }
-$"$(s)[$(derived.GuardCrashAtClient)]";
-```
-
-The `GuardCrashAtCliebt` calls the event and return the exception.
-New calls will be added right before returning s therefore,
-add additional postfix `[CrashedAtServer][CrashedAtClient]` to `IndexRpc.txt`.
-
-----------------------------
-
-In order to make this work, you will have to declare a reflectable struct right below `RpcObjectReference`:
-```C++
-struct RpcException
+interface IDerived : IOne, ITwo
 {
-  WString message;
+  func GuardCrashAtClient() : string;
 }
 ```
 
-It should also be JSON serialized just like `RpcException`. Following thing will be affected:
-- In `TODO_RPC_Definition.md`, you have to add that `RpcException` and `RpcObjectReference` could not be in any function return values, or function/event arguments.
-  - Implement it.
-  - Make three errors, one for return value, two for function/event arguments.
-  - Error code begins with H, continue the H series numbers.
-  - You will need to add enough AnalyzerError for it.
-- In `TODO_RPC_Json.md` you have to mention that `RpcException` is serialized just like `RpcObjectReference` in the standard way, and fix the `## Expected format of generated .d.ts files` section.
-  - Implement it.
-- In `IRpcObjectOps::InvokeMethod` which calls the actual method, you need to try-catch it, and when exception happens, return `RpcException`. Because `RpcException` will never be the return type, it is safe without ambiguity.
-- During serialization, handle it properly.
-- In a wrapper calling `IRpcObjectOps::InvokeMethod`, if the return value is `RpcException`, it raises an exception with that message, and `EndInvokeMethod` don't need to call.
+In `CreateDerived`, the implementation will attach a handler to `CrashAtServer` and raise `"CrashedAtServer"`.
+In `clientMain`, attach a handler to `CrashAtClient` and raise `"CrashedAtClient"`.
 
-At the end, since new JSON protocols are added, you need to go to `Test/TypeScript`, run `prepare.ps1` followed by `npm run build`.
-And make sure these documents are updated:
-- `TODO_RPC_Definition.md` mentioning the new error.
-- `TODO_RPC_Json.md` mentioning additional JSON serialization thing.
-- `TODO_RPC_GeneratedWrappers.md` if necessary.
+Now we have to call them to test the exception. `clientMain` calls them like this:
+```Workflow
+try { derived.CrashAtServer(); } catch (ex) { s = $"$(s)[$(ex)]"; }
+s = $"$(s)[$(derived.GuardCrashAtClient())]";
+```
+
+`GuardCrashAtClient` calls the event and returns the exception message:
+```Workflow
+override func GuardCrashAtClient() : string
+{
+  try { CrashAtClient(); } catch (ex) { return ex; }
+  return "";
+}
+```
+
+New calls will be added right before returning `s`, therefore add additional postfix `[CrashedAtServer][CrashedAtClient]` to `IndexRpc.txt`.
+
+----------------------------
+
+In order to make this work, update `IRpcObjectEventOps::InvokeEvent` to return `system::RpcException[int]` instead of `void`.
+`RpcException` already exists. The key of the returned dictionary is the client id of the lifecycle whose event handler raised an exception. The value is the `RpcException` containing that exception message.
+
+The expected behavior is:
+- An event broadcast must attempt to deliver the event to every lifecycle that should receive it.
+- If only part of the lifecycles raise exceptions while handling the event, the result dictionary contains only those lifecycles.
+- If no lifecycle raises an exception, the result dictionary is empty.
+- If multiple lifecycles raise exceptions, the lifecycle that triggered the event receives all of them together, keyed by client id.
+- Exceptions from one lifecycle must not prevent other lifecycles from receiving the same event.
+
+Following things will be affected:
+- In `IRpcObjectEventOps::InvokeEvent`, which calls the actual event, you need to try-catch it, and when exception happens, return a dictionary containing one item: `_lc.ClientId` to `RpcException`.
+  - Keep the event suppression flag set before raising the local event.
+  - Keep clearing the event suppression flag in `finally`, even when an exception is caught and converted to the dictionary.
+  - Unknown event ids should still behave consistently with the new return value path.
+- In a generated local event listener, after calling `IRpcDispatcher::BroadcastFromClient_ObjectEventOps(...)->InvokeEvent(...)`, check the returned `RpcException[int]`.
+  - If the dictionary is empty, finish normally.
+  - If the dictionary is not empty, raise an exception on the lifecycle that triggered the event.
+  - The returned dictionary is an internal transport value. It must not be exposed to Workflow script catch variables; `catch (ex)` still receives a string exception message.
+- In the dispatcher or broadcast object-event ops implementation, aggregate all dictionaries returned from target lifecycles.
+  - Do not stop at the first returned exception.
+  - Preserve the client id keys from every target lifecycle.
+  - This should work when only one lifecycle raises and when multiple lifecycles raise.
+- During JSON serialization, reuse the existing support for serializing `RpcException[int]`.
+  - The dictionary key is the lifecycle client id.
+  - JSON event receiving should deserialize arguments before raising the local event, catch exceptions into the returned dictionary, and serialize the dictionary back to the trigger lifecycle.
+  - JSON event sending should deserialize the returned dictionary before deciding whether to raise an exception.
+- Update generated wrappers and reflection declarations to use the new return type of `IRpcObjectEventOps::InvokeEvent` everywhere.
+- Update mocks and tests that implement or wrap `IRpcObjectEventOps`, including JSON mocks, so they aggregate and forward event exceptions instead of dropping them.
+
+At the end, make sure these documents are updated:
+- `TODO_RPC_GeneratedWrappers.md` mentioning how generated object event ops return `RpcException[int]` and how generated event senders raise exceptions for non-empty dictionaries without exposing client ids to Workflow script.
+- `TODO_RPC_Definition.md` if the definition document needs to mention the new event exception behavior.
+
+`TODO_RPC_Json.md` does not need an update for this task, because the exception map uses the existing JSON serialization support.


### PR DESCRIPTION
### Motivation

- Clarify and extend the `Rpc/Inheritance` sample to exercise event exception propagation and to add a `GuardCrashAtClient` test helper in `IDerived`. 
- Define a consistent behavior for event broadcasts when handlers raise exceptions so that exceptions from individual lifecycles are aggregated and reported back to the trigger lifecycle.
- Consolidate the implementation guidance and affected artifacts so implementers know which interfaces, generated wrappers, mocks, and docs to update.

### Description

- Add `GuardCrashAtClient` to the sample `IDerived` API and update the `clientMain` example to call `GuardCrashAtClient()` and handle `CrashAtClient`/`CrashAtServer` posting, and note the expected `IndexRpc.txt` postfix. 
- Change the event invocation contract guidance so `IRpcObjectEventOps::InvokeEvent` returns `system::RpcException[int]` instead of `void`, with the dictionary key being the lifecycle client id and the value the `RpcException` for that lifecycle. 
- Specify runtime behavior: broadcasts must attempt delivery to all lifecycles, aggregate exception dictionaries from targets (preserving client ids), convert non-empty aggregate dictionaries into an exception on the triggering lifecycle, and keep event suppression flags and finally-behavior intact when catching exceptions. 
- Call out affected artifacts that must be updated in implementation: generated local event listeners, dispatcher/broadcast object-event ops, JSON (reuse existing `RpcException[int]` support), generated wrappers and reflection declarations, mocks/tests that implement `IRpcObjectEventOps`, and the docs `TODO_RPC_GeneratedWrappers.md` and `TODO_RPC_Definition.md` as needed.

### Testing

- No automated tests were run as part of this documentation-only change. 
- The task text instructs running TypeScript preparation and build (`prepare.ps1` and `npm run build`) after implementing the protocol changes, but that was not executed in this PR. 
- Implementers are expected to add/adjust unit tests and mocks to verify aggregated event-exception behavior when applying the described code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1b84d4348332ab6445aa51cd9db0)